### PR TITLE
Distribution Protocol v0.3 (close open review findings) + repo controls for a hash-pinned spec

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Byte-stable checkouts. Distribution Protocol §2 pins results to the SHA-256
+# of the exact bytes of the Core specification (and the protocol self-hash to
+# this protocol's bytes). A checkout that rewrites line endings would change
+# those hashes silently, so every text file is normalized to LF everywhere,
+# regardless of the local core.autocrlf setting.
+* text=auto eol=lf
+*.md text eol=lf
+LICENSE text eol=lf

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What
+
+<!-- One paragraph: which document(s), what changed, why. -->
+
+## Checklist
+
+- [ ] **No case content.** Nothing in this PR (commits, description, attachments) is or identifies `base.bundle`, `oracle.pack`, a full `manifest.yaml`, Oracle material, run records, or a Source Event. See `CONTRIBUTING.md`.
+- [ ] If a normative document changed: version bumped in its header and a dated changelog entry added (patch = editorial, minor = normative).
+- [ ] If a normative document changed: documents pinning to the old version updated (`Companion to …` lines, `PLAN.md`).
+- [ ] If `AMBER-Core-Specification.md` changed: the change is intentional and versioned — every byte change alters `spec_sha256`.
+- [ ] No Core invariant (§4) or boundary (§5) is weakened; Core `§` citations checked against the current text.
+- [ ] Relative links resolve (CI link check passes).

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,8 +13,8 @@ jobs:
     name: relative links resolve
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: lycheeverse/lychee-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           # Offline: only local file targets and fragments are checked, so the
           # job cannot flake on external hosts and makes no network requests.
@@ -25,7 +25,7 @@ jobs:
     name: spec bytes are UTF-8 / LF / no BOM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: check
         shell: bash
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: relative links resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          # Offline: only local file targets and fragments are checked, so the
+          # job cannot flake on external hosts and makes no network requests.
+          args: --offline --no-progress --include-fragments --root-dir "${{ github.workspace }}" '**/*.md'
+          fail: true
+
+  encoding:
+    name: spec bytes are UTF-8 / LF / no BOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          status=0
+          while IFS= read -r -d '' f; do
+            if LC_ALL=C grep -q $'\r' "$f"; then
+              echo "::error file=$f::contains CRLF line endings (Distribution Protocol §2 requires LF)"; status=1
+            fi
+            if [ "$(head -c 3 "$f" | od -An -tx1 | tr -d ' \n')" = "efbbbf" ]; then
+              echo "::error file=$f::starts with a UTF-8 BOM (Distribution Protocol §2 forbids it)"; status=1
+            fi
+            if ! iconv -f UTF-8 -t UTF-8 "$f" >/dev/null 2>&1; then
+              echo "::error file=$f::is not valid UTF-8"; status=1
+            fi
+            if [ -s "$f" ] && [ "$(tail -c 1 "$f" | od -An -tx1 | tr -d ' \n')" != "0a" ]; then
+              echo "::error file=$f::does not end with a newline"; status=1
+            fi
+          done < <(git ls-files -z -- '*.md' LICENSE)
+          exit "$status"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ A PR that changes a normative document must, in the same PR:
 `AMBER-Core-Specification.md` is pinned by `spec_sha256` in every Case Manifest (Distribution §2). **Every byte change to that file changes the hash** and breaks comparability between cases built before and after it. Consequences:
 
 - do not reformat, re-wrap, or "clean up" whitespace in Core without a versioned reason;
-- files are stored as UTF-8 with LF line endings and no BOM, enforced by `.gitattributes` — do not override it locally;
+- files are stored with LF line endings, enforced by `.gitattributes`; UTF-8 validity and the no-BOM rule are enforced by CI (`.github/workflows/docs.yml`) — do not override either locally;
 - when Core does change, expect producers to treat existing cases as pinned to the old hash; that is the design working, not a bug.
 
 Compute the hash of the current Core bytes with `sha256sum AMBER-Core-Specification.md` on a clean checkout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+This repository is the **public channel** of AMBER (Distribution Protocol §1). It holds the specification and its companion documents, and nothing that belongs to a case. Contributions are welcome within those bounds.
+
+## What never goes here
+
+The public/private split has no exceptions. Do not submit, attach, or paste — in a commit, a PR description, an issue, or a review comment:
+
+- `base.bundle`, `oracle.pack`, or any `manifest.yaml` (redacted summaries excluded);
+- rubrics, expected outputs, post-cutoff patches, known-bad responses, or any other Oracle material;
+- run records, per-criterion scores, or candidate transcripts;
+- anything that identifies a case's Source Event (repository, commit, issue, cutoff commit).
+
+Case content that reaches this repository — even briefly, even in a closed PR — retires the case permanently (Distribution §6). Git history is public; there is no undo. If you are unsure whether something is case content, do not post it; describe the problem abstractly instead.
+
+## Documents and how they change
+
+Every normative document carries its own version and a dated changelog inline, at the top of the file. The revision policy is Core's and applies to all of them:
+
+| Change | Bump | Example |
+|---|---|---|
+| Editorial, portability, or citation fix; no normative change | patch (`0.x.y`) | fixing a wrong `§` reference |
+| Normative addition or clarification | minor (`0.x`) | a new required manifest field |
+| Anything that weakens sealing, audit, preregistration, or data controls | not accepted | Core §5.7 |
+
+A PR that changes a normative document must, in the same PR:
+
+1. bump the version in the header line and add a changelog entry stating what changed and which bump it is;
+2. update any document that pins to the old version (for example, a protocol's "Companion to Core vX.Y.Z" line, `PLAN.md`);
+3. re-verify that no Core invariant (§4) or boundary (§5) is weakened, and say so in the PR.
+
+`PLAN.md` and `README.md` are not normative and need no version bump. Where they conflict with Core, Core wins.
+
+### The Core specification is hash-pinned
+
+`AMBER-Core-Specification.md` is pinned by `spec_sha256` in every Case Manifest (Distribution §2). **Every byte change to that file changes the hash** and breaks comparability between cases built before and after it. Consequences:
+
+- do not reformat, re-wrap, or "clean up" whitespace in Core without a versioned reason;
+- files are stored as UTF-8 with LF line endings and no BOM, enforced by `.gitattributes` — do not override it locally;
+- when Core does change, expect producers to treat existing cases as pinned to the old hash; that is the design working, not a bug.
+
+Compute the hash of the current Core bytes with `sha256sum AMBER-Core-Specification.md` on a clean checkout.
+
+## Style
+
+- Normative documents are written in English; `README.md` is Chinese with an English pointer to the normative entry point. Keep it that way unless a maintainer decides otherwise.
+- Cite Core by section (`Core §4.5`), and cite the Core-unnumbered "Purpose and use" section by name. Check the citation against the current Core text; wrong section numbers were the most common finding in past reviews.
+- Prefer stating a limit honestly over stating a guarantee vaguely (Core §6, Distribution §8).
+- Relative links between documents must resolve; CI checks them.
+
+## Review
+
+Normative changes go through review before merge; the maintainers have used structured multi-reviewer passes for every published version so far. Open the PR with the checklist in the template filled in. If a reviewer's finding is accepted but deferred, record it in `PLAN.md` (open design questions) so it is not lost.
+
+## License
+
+By contributing you agree that your contributions are licensed under the Apache License 2.0 (see `LICENSE`).

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,9 +19,12 @@ Specification; where this file and Core conflict, Core wins.
   `spec_sha256` is checkout-stable; CI checks relative links and spec-file
   encoding; `CONTRIBUTING.md` states the no-case-content rule and the
   revision policy.
-- **Index instance live:** `hash-index/v2026-09.md` is the first published
-  index document (21 cases, alias + bundle/oracle hashes) — the data
-  instance of Distribution §4, ahead of the M5 signing/key tooling.
+- **Index prototype live:** `hash-index/v2026-09.md` publishes per-case
+  aliases and truncated bundle/oracle hashes for the 21 active cases. It is
+  a **pre-conformance prototype** of the Distribution §4 index: it does not
+  yet carry the §4 entry field set (manifest sha256, `spec_sha256`,
+  `cutoff_utc`, state) or a producer signature; full conformance lands with
+  the M5 tooling.
 
 ## Milestones
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,21 +4,32 @@ Status, milestones, and open design questions for turning the published
 specification into an executable evaluation. Companion to the Core
 Specification; where this file and Core conflict, Core wins.
 
-## Status (2026-08)
+## Status (2026-09)
 
-- **Published:** AMBER Core Specification v0.2.2; Distribution Protocol v0.2.
+- **Published:** AMBER Core Specification v0.2.2; Distribution Protocol v0.3
+  (v0.3 closes every finding left open by the review of the v0.2 publication:
+  detached manifest signature, enumerated redacted summary, leak-date
+  validity window, corrected verification matrix, `spec_sha256` byte
+  definition, Core citation fixes).
 - **Not yet published:** `schemas/`, `profiles/`, case-building tooling, and a
   reference runner. A conformant run is **not executable from this repository
   alone today** — this file exists to make that gap explicit and to sequence
   the work that closes it.
+- **Repository controls in place:** `.gitattributes` pins LF/UTF-8 so
+  `spec_sha256` is checkout-stable; CI checks relative links and spec-file
+  encoding; `CONTRIBUTING.md` states the no-case-content rule and the
+  revision policy.
 
 ## Milestones
 
 - **M1 — Case tooling.** The forge-neutral build script promised by
   `protocols/distribution.md` §3 (produces `base.bundle`, `oracle.pack`,
-  signed `manifest.yaml`); manifest JSON Schema + validator.
+  `manifest.yaml`, and the detached `manifest.yaml.sig`); manifest JSON
+  Schema + validator; the redacted-summary generator restricted to the
+  closed field set of Distribution §5.1.
   *Exit:* build a case from an arbitrary git repository; validator rejects
-  malformed manifests; bundle passes `git bundle verify`.
+  malformed manifests and summaries containing any excluded field; bundle
+  passes `git bundle verify`; signature verifies against the published key.
 - **M2 — Reference runner.** Fixed-harness candidate runner: an external
   agent runtime as the candidate scaffold, launched inside an isolated
   container (no default route; egress only through the manifest-declared
@@ -43,7 +54,9 @@ Raised by external review (2026-08); resolve in the milestone that owns them:
    identity and independence, but drift, blinding, and agreement mechanics
    for LLM judges are unspecified.
 2. **Index trust root** (M5): the index is single-producer-signed; key
-   rotation and third-party witnessing are unspecified.
+   rotation and third-party witnessing are unspecified. Distribution §5.1
+   now states where the key is published (next to the index) and explicitly
+   defers rotation and witnessing here.
 3. **Difficulty calibration** (M4): no guidance with teeth against
    saturation — a single easy case cannot discriminate (observed in pilot
    work: near-ceiling pass rates on an easy-medium repair case).

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,6 +19,9 @@ Specification; where this file and Core conflict, Core wins.
   `spec_sha256` is checkout-stable; CI checks relative links and spec-file
   encoding; `CONTRIBUTING.md` states the no-case-content rule and the
   revision policy.
+- **Index instance live:** `hash-index/v2026-09.md` is the first published
+  index document (21 cases, alias + bundle/oracle hashes) — the data
+  instance of Distribution §4, ahead of the M5 signing/key tooling.
 
 ## Milestones
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@
 ## 内容
 
 - [AMBER-Core-Specification.md](AMBER-Core-Specification.md) — 规范本体：目的、定义、机制、8 条不变量、8 条边界、认识论限制、命名评审、采用规则
-- [protocols/distribution.md](protocols/distribution.md) — 案件跨主机分发协议：公开/私有频道划分、固定构造的 git bundle、签名清单、公开哈希索引、密封探针、运行记录、可比性
+- [protocols/distribution.md](protocols/distribution.md) — 案件跨主机分发协议（v0.3）：公开/私有频道划分、固定构造的 git bundle、分离式签名清单、公开索引、密封探针、泄漏窗口的裁定规则、运行记录、可比性与验证矩阵
 - [hash-index/v2026-09.md](hash-index/v2026-09.md) — 公开哈希索引：当前评测题集(21 案)每案的别名 + bundle/oracle 双哈希;结果仓每期矩阵以此为准对照
-- [PLAN.md](PLAN.md) — 状态、里程碑(建案工具 → 参考运行器 → 评分与裁判 → 统计 → 公开索引)、待决设计问题
+- [PLAN.md](PLAN.md) — 状态、里程碑（建案工具 → 参考运行器 → 评分与裁判 → 统计 → 公开索引）、待决设计问题
+- [CONTRIBUTING.md](CONTRIBUTING.md) — 贡献规则：**本仓库绝不接收案件内容**、规范文档的版本与修订政策、Core 规范按字节哈希锁定的含义
 
 ## 周测成绩(结果仓库)
 

--- a/protocols/distribution.md
+++ b/protocols/distribution.md
@@ -1,10 +1,10 @@
 # AMBER Distribution Protocol
 
-Draft v0.3, 2026-09-06. Companion to AMBER Core Specification v0.2.2. This protocol is intended to preserve Core invariants (§4) and boundaries (§5) without weakening; each revision is re-verified against the frozen Core before publication. Where this protocol and Core conflict, Core wins. This document follows Core's revision policy (patch = editorial, minor = normative addition or clarification).
+Draft v0.3, 2026-09-07. Companion to AMBER Core Specification v0.2.2. This protocol is intended to preserve Core invariants (§4) and boundaries (§5) without weakening; each revision is re-verified against the frozen Core before publication. Where this protocol and Core conflict, Core wins. This document follows Core's revision policy (patch = editorial, minor = normative addition or clarification).
 
 *v0.2, 2026-08-21. Incorporates every accepted correction from the structured review of the v0.1 draft: egress-scoped eligibility, transport-layer seal probe with scoped positive control, signed manifests, the public hash index, pinned bundle construction, the run-state split, and the explicit verification matrix.*
 
-*v0.3, 2026-09-06. Closes the post-publication review findings on v0.2: manifest signature made detached (`manifest.yaml.sig`) so coverage is well-defined (§3, §5.1); redacted manifest summary's field set enumerated (§5.1); leak-window runs routed to `pending_adjudication` and validity keyed to the leak date, not the retirement date (§6); verification matrix corrected — external consumers verify all three artifact hashes by value against the index and none by possession (§7.1); `spec_sha256` byte definition and computation fixed (§2); index described as content-free, not hash-only, with the public `cutoff_utc` disclosure recorded as a limit (§1, §4, §8); two Core miscitations corrected (§1, §8). Normative clarifications → minor bump.*
+*v0.3, 2026-09-07. Closes the post-publication review findings on v0.2: manifest signature made detached (`manifest.yaml.sig`) so coverage is well-defined (§3, §5.1); redacted manifest summary's field set enumerated (§5.1); leak-window runs routed to `pending_adjudication` and validity keyed to the leak date, not the retirement date (§6); verification matrix corrected — external consumers verify `spec_sha256` by possession and the `base.bundle` / `oracle.pack` hashes by value against the signed index (§7.1); `spec_sha256` byte definition and computation fixed (§2); index described as content-free, not hash-only, with the public `cutoff_utc` disclosure recorded as a limit (§1, §4, §8); two Core miscitations corrected (§1, §8). Review round on the v0.3 draft: comparability extended to `cutoff_utc` (§7); `index_version` defined as a property of the index, not an entry field (§4); the manifest records the leak check's result, not only its date (§3); run records asserted to external consumers must be producer-signed (§7, §7.1). Normative clarifications → minor bump.*
 
 ## 1. The split: public spec, private cases
 
@@ -21,7 +21,7 @@ Every Case Manifest records `spec_sha256` — the SHA-256 of the exact Core spec
 
 "Exact bytes" means the file as committed to the public channel: UTF-8, LF line endings, no byte-order mark, computed over the whole file (`sha256sum AMBER-Core-Specification.md`). The public repository enforces this encoding through `.gitattributes`; a checkout that rewrites line endings or re-encodes the file yields a different hash and must not be used as the pinning source. The same rule applies to the protocol self-hash recorded in the manifest (§3).
 
-## 3. Case package: three parts
+## 3. Case package: three artifacts, one detached signature
 
 A case is three artifacts plus the detached signature of the manifest, produced by one forge-neutral build script:
 
@@ -29,7 +29,7 @@ A case is three artifacts plus the detached signature of the manifest, produced 
 |---|---|---|
 | `base.bundle` | `git bundle create` of the source repository's history up to the cutoff commit | candidate-visible |
 | `oracle.pack` | post-cutoff commits/patch/tests, the preregistered rubric, evaluator materials | sealed |
-| `manifest.yaml` | provenance, `cutoff_utc`, the resolved cutoff commit, the time-to-topology mapping rule and its evidence class, the preregistered cutoff rule and its script-output hash, `spec_sha256`, sha256 of both artifacts, the declared `candidate_input_bundle` (Core §4.4), the available-information manifest (Core §5.2), the eligibility determination and its evidence class (§5), producer identity and signing-key identifier (§5), the leak-check procedure and its last run date, retirement state, and the sha256 of this protocol document | private |
+| `manifest.yaml` | provenance, `cutoff_utc`, the resolved cutoff commit, the time-to-topology mapping rule and its evidence class, the preregistered cutoff rule and its script-output hash, `spec_sha256`, sha256 of both artifacts, the declared `candidate_input_bundle` (Core §4.4), the available-information manifest (Core §5.2), the eligibility determination and its evidence class (§5), producer identity and signing-key identifier (§5), the leak-check procedure, its last run date, and its result (`passed` / `failed`), retirement state, and the sha256 of this protocol document | private |
 | `manifest.yaml.sig` | detached signature over the exact bytes of `manifest.yaml`, made with the key identified in the manifest (§5.1) | private |
 
 The signature is detached rather than embedded so that its coverage is unambiguous: it covers every byte of `manifest.yaml`, and verifying it needs no canonical re-serialization of YAML. Any change to the manifest — including to the artifact hashes it embeds — invalidates the signature.
@@ -50,6 +50,8 @@ The public channel carries an append-only, producer-signed case index. Each entr
 
 `case_id` · manifest sha256 · `base.bundle` sha256 · `oracle.pack` sha256 · `spec_sha256` · `cutoff_utc` · state (`active` / `retired` + date)
 
+The index itself carries a monotonically increasing `index_version` (an append-only sequence number or a head hash covering every entry to date). `index_version` is a property of the index, not an entry field; run records (§7) and redacted summaries (§5.1) cite the `index_version` of the index that carries the corresponding entry.
+
 Rules:
 
 - The index entry — including `oracle.pack` sha256 — is published **before the case's first run**. Runs predating publication are not Core results (Core §4.6: preregistration).
@@ -63,7 +65,7 @@ Rules:
 
 - The producer host builds the case from its own forge and transfers to the evaluation host: `base.bundle`, the **full `manifest.yaml`**, and its detached signature `manifest.yaml.sig` (§3). The evaluation host is trusted — it will hold `oracle.pack` in its sealed store — so redaction never applies to it. The signature covers every byte of `manifest.yaml`, which embeds both artifact hashes; the evaluation host verifies the signature against the producer's published key, then the bundle hash, before any run. Transfer is authenticated. The producer's public key is published in the public channel next to the index (§4), so the same key verifies both; key rotation and third-party witnessing are outside this protocol and tracked as an open design question of the index implementation.
 - The producer may additionally publish a **redacted manifest summary** for external parties who need provenance without private-channel access. Its field set is closed — exactly these fields, no others:
-  `case_id` · manifest sha256 · `base.bundle` sha256 · `oracle.pack` sha256 · `spec_sha256` · protocol sha256 · `cutoff_utc` · profile identifier · isolation class of the eligibility determination (`full_isolation` / `allowlisted`; never the allowlist itself) · construction parameters (git version, bundle format version, hash algorithm, bundle size) · producer identity and signing-key identifier · retirement state · `index_version` of the corresponding index entry.
+  `case_id` · manifest sha256 · `base.bundle` sha256 · `oracle.pack` sha256 · `spec_sha256` · protocol sha256 · `cutoff_utc` · profile identifier · isolation class of the eligibility determination (`full_isolation` / `allowlisted`; never the allowlist itself) · construction parameters (git version, bundle format version, hash algorithm, bundle size) · producer identity and signing-key identifier · retirement state · `index_version` of the index carrying this case's entry (§4).
   Everything else in the manifest is excluded, in particular: the resolved cutoff commit, source-identifying provenance, the time-to-topology evidence, the available-information manifest, `candidate_input_bundle`, oracle paths, the rubric, the cutoff rule and its script-output hash, and the leak-check procedure. The summary is itself signed (detached, same key). Its audience is external consumers — never the candidate, and never a substitute for the full manifest at the evaluation host.
 
 ### 5.2 Eligibility and isolation
@@ -93,9 +95,9 @@ Validity of earlier runs is keyed to the **leak date** — when the content beca
 
 ## 7. Run records and comparability
 
-Every run emits a structured record: manifest sha256, `index_version` and the retirement-check result, the seal-probe results (including the mechanism-level isolation check for full-isolation runs), candidate provider/model, per-criterion scores, the terminal state (Core §5.6), and sha256 of every artifact produced. Records are collected to the results store in the private channel; the public channel carries at most rubric-structure-free aggregates.
+Every run emits a structured record: manifest sha256, `index_version` and the retirement-check result, the seal-probe results (including the mechanism-level isolation check for full-isolation runs), candidate provider/model, per-criterion scores, the terminal state (Core §5.6), and sha256 of every artifact produced. Records are collected to the results store in the private channel; the public channel carries at most rubric-structure-free aggregates. A run record asserted to an external consumer must be signed by the producer (detached, same key as §5.1); by-value verification (§7.1) consumes only signed run records.
 
-Comparability across hosts requires equal `spec_sha256` AND equal `base.bundle` sha256 AND equal `oracle.pack` sha256 AND equal construction parameters (git version, bundle format version, hash algorithm) — same ruler, same exam; construction parameters plus hashes, never hashes alone.
+Comparability across hosts requires equal `spec_sha256` AND equal `cutoff_utc` AND equal `base.bundle` sha256 AND equal `oracle.pack` sha256 AND equal construction parameters (git version, bundle format version, hash algorithm) — same ruler, same exam; construction parameters plus hashes, never hashes alone. `cutoff_utc` is asserted directly rather than via manifest sha256 because manifests of the same exam legitimately drift (leak-check dates, retirement state) while the exam's information boundary does not.
 
 ### 7.1 Verification matrix
 
@@ -104,7 +106,7 @@ Two different verification strengths are in play. Verification **by possession**
 | Verifier | By possession | By value |
 |---|---|---|
 | Evaluation host | `spec_sha256`, `base.bundle` sha256, `oracle.pack` sha256, manifest signature — it holds all the bytes | — |
-| External result consumer | `spec_sha256` only (the Core specification is public) | `base.bundle` sha256 and `oracle.pack` sha256: run record against the signed index entry (§4) and, if published, the signed redacted summary (§5.1). It never holds the bundle or the oracle, so it can confirm that the hashes match, not that the bytes exist or are what the manifest says. |
+| External result consumer | `spec_sha256` only (the Core specification is public) | `base.bundle` sha256 and `oracle.pack` sha256: signed run record against the signed index entry (§4) and, if published, the signed redacted summary (§5.1). It never holds the bundle or the oracle, so it can confirm that the hashes match, not that the bytes exist or are what the manifest says. |
 
 ## 8. Honest limits
 

--- a/protocols/distribution.md
+++ b/protocols/distribution.md
@@ -1,31 +1,38 @@
 # AMBER Distribution Protocol
 
-Draft v0.2, 2026-08-21. Companion to AMBER Core Specification v0.2.2. This protocol is intended to preserve Core invariants (§4) and boundaries (§5) without weakening; v0.2 was re-verified against the frozen Core before publication. Where this protocol and Core conflict, Core wins.
+Draft v0.3, 2026-09-06. Companion to AMBER Core Specification v0.2.2. This protocol is intended to preserve Core invariants (§4) and boundaries (§5) without weakening; each revision is re-verified against the frozen Core before publication. Where this protocol and Core conflict, Core wins. This document follows Core's revision policy (patch = editorial, minor = normative addition or clarification).
 
 *v0.2, 2026-08-21. Incorporates every accepted correction from the structured review of the v0.1 draft: egress-scoped eligibility, transport-layer seal probe with scoped positive control, signed manifests, the public hash index, pinned bundle construction, the run-state split, and the explicit verification matrix.*
+
+*v0.3, 2026-09-06. Closes the post-publication review findings on v0.2: manifest signature made detached (`manifest.yaml.sig`) so coverage is well-defined (§3, §5.1); redacted manifest summary's field set enumerated (§5.1); leak-window runs routed to `pending_adjudication` and validity keyed to the leak date, not the retirement date (§6); verification matrix corrected — external consumers verify all three artifact hashes by value against the index and none by possession (§7.1); `spec_sha256` byte definition and computation fixed (§2); index described as content-free, not hash-only, with the public `cutoff_utc` disclosure recorded as a limit (§1, §4, §8); two Core miscitations corrected (§1, §8). Normative clarifications → minor bump.*
 
 ## 1. The split: public spec, private cases
 
 AMBER separates into two channels with no exceptions:
 
-- **Public channel** (e.g. the public spec repository): the Core specification, case-building tooling, the manifest schema, and a hash-only case index — an integrity reference proving that a case exists and is unmodified, carrying no content.
-- **Private channel** (an access-restricted forge or store): `base.bundle`, `oracle.pack`, the full `manifest.yaml`, and the results store.
+- **Public channel** (e.g. the public spec repository): the Core specification, case-building tooling, the manifest schema, and a content-free case index — artifact hashes plus the minimal metadata enumerated in §4 (`cutoff_utc`, state). It is an integrity reference proving that a case exists and is unmodified; it carries no case content.
+- **Private channel** (an access-restricted forge or store): `base.bundle`, `oracle.pack`, the full `manifest.yaml` and its signature, and the results store.
 
-Rationale: a case's value is its controlled leak status (Core §5.1). Case content reaching a public channel burns the case permanently — future candidates may train on it (§6 of this protocol).
+Rationale: a case's value is its controlled leak status (Core, Purpose and use; Core §5.3, candidate boundary). Case content reaching a public channel burns the case permanently — future candidates may train on it (§6 of this protocol).
 
 ## 2. Spec pinning
 
 Every Case Manifest records `spec_sha256` — the SHA-256 of the exact Core specification bytes — not a version string alone. Cross-host results are comparable only when `spec_sha256` matches. Pinning to "latest" is a comparability failure: version strings move, hashes do not.
 
+"Exact bytes" means the file as committed to the public channel: UTF-8, LF line endings, no byte-order mark, computed over the whole file (`sha256sum AMBER-Core-Specification.md`). The public repository enforces this encoding through `.gitattributes`; a checkout that rewrites line endings or re-encodes the file yields a different hash and must not be used as the pinning source. The same rule applies to the protocol self-hash recorded in the manifest (§3).
+
 ## 3. Case package: three parts
 
-A case is three artifacts, produced by one forge-neutral build script:
+A case is three artifacts plus the detached signature of the manifest, produced by one forge-neutral build script:
 
 | Artifact | Contents | Visibility |
 |---|---|---|
 | `base.bundle` | `git bundle create` of the source repository's history up to the cutoff commit | candidate-visible |
 | `oracle.pack` | post-cutoff commits/patch/tests, the preregistered rubric, evaluator materials | sealed |
-| `manifest.yaml` | provenance, `cutoff_utc`, the resolved cutoff commit, the time-to-topology mapping rule and its evidence class, the preregistered cutoff rule and its script-output hash, `spec_sha256`, sha256 of both artifacts, the declared `candidate_input_bundle` (Core §4.4), the available-information manifest (Core §5.2), the eligibility determination and its evidence class (§5), producer identity and signature (§5), the leak-check procedure and its last run date, retirement state, and the sha256 of this protocol document | private |
+| `manifest.yaml` | provenance, `cutoff_utc`, the resolved cutoff commit, the time-to-topology mapping rule and its evidence class, the preregistered cutoff rule and its script-output hash, `spec_sha256`, sha256 of both artifacts, the declared `candidate_input_bundle` (Core §4.4), the available-information manifest (Core §5.2), the eligibility determination and its evidence class (§5), producer identity and signing-key identifier (§5), the leak-check procedure and its last run date, retirement state, and the sha256 of this protocol document | private |
+| `manifest.yaml.sig` | detached signature over the exact bytes of `manifest.yaml`, made with the key identified in the manifest (§5.1) | private |
+
+The signature is detached rather than embedded so that its coverage is unambiguous: it covers every byte of `manifest.yaml`, and verifying it needs no canonical re-serialization of YAML. Any change to the manifest — including to the artifact hashes it embeds — invalidates the signature.
 
 ### 3.1 Bundle construction (pinned)
 
@@ -48,13 +55,16 @@ Rules:
 - The index entry — including `oracle.pack` sha256 — is published **before the case's first run**. Runs predating publication are not Core results (Core §4.6: preregistration).
 - Retirement writers are authenticated; entries are never edited or deleted, only superseded by later append-only entries.
 - Every conformant host consults the index before running a case; the run record carries `index_version` and the retirement-check result (§7).
+- Entries carry exactly the fields listed above and nothing else. `cutoff_utc` and state are metadata, not case content, but `cutoff_utc` is a real disclosure: it weakly narrows the set of possible Source Events (§8). It is published because comparability (§7) and retirement checks need it; no other manifest field is ever copied into the index.
 
 ## 5. Cross-forge, cross-host operation
 
 ### 5.1 Transfer and trust
 
-- The producer host builds the case from its own forge and transfers to the evaluation host: `base.bundle` and the **full signed `manifest.yaml`**. The evaluation host is trusted — it will hold `oracle.pack` in its sealed store — so redaction never applies to it. The manifest signature covers the entire manifest, which embeds both artifact hashes; the evaluation host verifies the signature and the bundle hash before any run. Transfer is authenticated.
-- The producer may additionally publish a **redacted manifest summary** for external parties who need provenance without private-channel access. The summary has an enumerated field set and redaction rules (no oracle paths, no rubric, no source-identifying provenance). Its audience is external consumers — never the candidate, and never a substitute for the full manifest at the evaluation host.
+- The producer host builds the case from its own forge and transfers to the evaluation host: `base.bundle`, the **full `manifest.yaml`**, and its detached signature `manifest.yaml.sig` (§3). The evaluation host is trusted — it will hold `oracle.pack` in its sealed store — so redaction never applies to it. The signature covers every byte of `manifest.yaml`, which embeds both artifact hashes; the evaluation host verifies the signature against the producer's published key, then the bundle hash, before any run. Transfer is authenticated. The producer's public key is published in the public channel next to the index (§4), so the same key verifies both; key rotation and third-party witnessing are outside this protocol and tracked as an open design question of the index implementation.
+- The producer may additionally publish a **redacted manifest summary** for external parties who need provenance without private-channel access. Its field set is closed — exactly these fields, no others:
+  `case_id` · manifest sha256 · `base.bundle` sha256 · `oracle.pack` sha256 · `spec_sha256` · protocol sha256 · `cutoff_utc` · profile identifier · isolation class of the eligibility determination (`full_isolation` / `allowlisted`; never the allowlist itself) · construction parameters (git version, bundle format version, hash algorithm, bundle size) · producer identity and signing-key identifier · retirement state · `index_version` of the corresponding index entry.
+  Everything else in the manifest is excluded, in particular: the resolved cutoff commit, source-identifying provenance, the time-to-topology evidence, the available-information manifest, `candidate_input_bundle`, oracle paths, the rubric, the cutoff rule and its script-output hash, and the leak-check procedure. The summary is itself signed (detached, same key). Its audience is external consumers — never the candidate, and never a substitute for the full manifest at the evaluation host.
 
 ### 5.2 Eligibility and isolation
 
@@ -73,7 +83,13 @@ Before every run, an evaluator-executed probe runs from the candidate's network 
 
 ## 6. Leak means retirement
 
-If any case artifact's content reaches a public channel, the case is permanently retired: the index marks it `retired` with the date, and it is never reused for a Core result. There is no partial leak and no re-sealing of burned material. A suspected leak maps to `pending_adjudication` (Core §5.6). Runs completed before the retirement date remain valid.
+If any case artifact's content reaches a public channel, the case is permanently retired: the index marks it `retired` with the date, and it is never reused for a Core result. There is no partial leak and no re-sealing of burned material. A suspected leak maps to `pending_adjudication` (Core §5.6).
+
+Validity of earlier runs is keyed to the **leak date** — when the content became reachable — not to the retirement date, which is only when the leak was discovered:
+
+- Runs completed before the leak date remain valid.
+- Runs completed between the leak date and the retirement date enter `pending_adjudication`; the adjudication authority declared by the profile (Core §5.8) determines, per run, whether the leaked content was reachable from that run's candidate vantage. Full-isolation runs with a passed mechanism-level check (§5.3) will normally be upheld; allowlisted runs are examined against their egress.
+- If the leak date cannot be established, it defaults to the date of the last leak check recorded as passed in the manifest (§3). A case whose manifest records no passed leak check has no valid runs after the leak is confirmed.
 
 ## 7. Run records and comparability
 
@@ -83,10 +99,12 @@ Comparability across hosts requires equal `spec_sha256` AND equal `base.bundle` 
 
 ### 7.1 Verification matrix
 
-| Verifier | Can verify |
-|---|---|
-| Evaluation host | all three artifact hashes + manifest signature (it holds the bytes) |
-| External result consumer | `spec_sha256` and `base.bundle` sha256 against the index; the `oracle.pack` leg only via the signed manifest |
+Two different verification strengths are in play. Verification **by possession** recomputes a hash from bytes the verifier holds. Verification **by value** checks that the same hash is asserted consistently by independently signed records (index entry, run record, redacted summary) without holding the bytes.
+
+| Verifier | By possession | By value |
+|---|---|---|
+| Evaluation host | `spec_sha256`, `base.bundle` sha256, `oracle.pack` sha256, manifest signature — it holds all the bytes | — |
+| External result consumer | `spec_sha256` only (the Core specification is public) | `base.bundle` sha256 and `oracle.pack` sha256: run record against the signed index entry (§4) and, if published, the signed redacted summary (§5.1). It never holds the bundle or the oracle, so it can confirm that the hashes match, not that the bytes exist or are what the manifest says. |
 
 ## 8. Honest limits
 
@@ -94,6 +112,7 @@ Comparability across hosts requires equal `spec_sha256` AND equal `base.bundle` 
 - The seal probe verifies physical unreachability at probe time; continuity between probe and run is unverified.
 - The eligibility rule's guarantee for full-isolation runs rests on the mechanism-level isolation check (§5.3), not on producer assertion.
 - The original-source path is a named residual risk: post-cutoff evidence may exist at the case's source outside any sealed store; only full isolation plus the mechanism check closes it.
-- The index proves integrity, not quality; retirement is reactive to discovered leaks.
+- The index proves integrity, not quality; retirement is reactive to discovered leaks, and the leak date it keys on (§6) is itself an investigation finding, not a measurement.
+- The public `cutoff_utc` in the index (§4) weakly narrows the set of possible Source Events. It is an accepted disclosure, not a leak of case content; producers of public-source cases should weigh it when choosing cutoffs that coincide with widely known events.
 - The same model evaluated from two different hosts is two independent contexts, not model diversity.
-- Distribution does not fix case selection bias (documented in Core §6 and the profile layer); it only moves cases safely.
+- Distribution does not fix case selection bias or difficulty calibration; those are profile-layer and statistics-protocol concerns, and Core §6 does not address them either. This protocol only moves cases safely.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two things: the Distribution Protocol moves to **v0.3**, closing every finding the review of #1 left open when v0.2 merged; and the repository gains the controls a public-channel, hash-pinned spec repo needs (`.gitattributes`, CI, `CONTRIBUTING.md`, PR template). `AMBER-Core-Specification.md` is **byte-for-byte unchanged** (`spec_sha256` = `755af5b7…5755e4`).

### `protocols/distribution.md` → v0.3

| Open finding from #1 review | Resolution |
|---|---|
| Signature is a manifest field yet said to cover the entire manifest | Signature is now **detached** (`manifest.yaml.sig`) over the exact bytes of `manifest.yaml`; manifest carries producer identity + signing-key id. No YAML canonicalization needed. (§3, §5.1) |
| Redacted summary's "enumerated field set" never enumerated | Closed field set enumerated, with explicit exclusions (resolved cutoff commit, provenance, `candidate_input_bundle`, rubric, allowlist, …). Summary is itself signed. (§5.1) |
| Validity keyed to retirement (discovery) date, not leak date | Validity keyed to the **leak date**; runs in the leak→retirement window go to `pending_adjudication` per Core §5.8; fallback to last passed leak check. (§6) |
| §7.1 contradicts §4 (external consumers *can* verify `oracle.pack` sha256 via index) | Matrix rewritten with a **by possession / by value** distinction: external consumers verify `spec_sha256` by possession and both artifact hashes by value against the signed index. (§7.1) |
| "Hash-only index carrying no content" overstates | Index described as content-free with `cutoff_utc` + state; the `cutoff_utc` disclosure is named as an accepted limit. (§1, §4, §8) |
| Miscitation: Core §5.1 for leak-status rationale | → Core "Purpose and use" + §5.3. (§1) |
| Miscitation: Core §6 for selection bias | Selection bias / difficulty calibration attributed to profile + statistics layers; Core §6 explicitly not claimed. (§8) |

Also: §2 now defines "exact bytes" (UTF-8, LF, no BOM, whole file, `sha256sum`) and §5.1 says where the producer key is published, deferring rotation/witnessing to the index open question. Normative clarifications → minor bump per Core's revision policy. All Core `§` citations re-checked against the current Core text.

### Repository controls

- **`.gitattributes`** — LF/UTF-8 for all text. Without it, a `core.autocrlf=true` checkout produces a different `spec_sha256` from the same commit. `git add --renormalize` showed zero churn, so existing hashes are unaffected.
- **CI (`.github/workflows/docs.yml`)** — two network-free jobs: lychee `--offline` relative-link + fragment check, and an encoding check (UTF-8, LF, no BOM, trailing newline) over tracked `.md` + `LICENSE`. Both verified locally, including that the link check fails on a broken link/fragment.
- **`CONTRIBUTING.md`** — the no-case-content rule (a leak retires the case; git history is public), the revision policy and what a normative PR must include, and why byte changes to Core are never free.
- **PR template** — the above as a checklist.
- **`PLAN.md` / `README.md`** — pinned to v0.3, M1 exit criteria extended to the detached signature and the closed summary field set, CONTRIBUTING linked.

## Deliberately not done

- No edits to Core (would change `spec_sha256`; the two candidate nits — §8 layering not listing `distribution`, `AMBER.md` "planned" — are not worth a hash change).
- No `schemas/` / M1 tooling: Core §8 says schemas *inherit* the SHRE v0.1 corpus, which is not in this repository, so authoring them here would be guesswork.

## Checklist

- [x] **No case content.**
- [x] Normative document changed: version bumped, dated changelog entry added.
- [x] Documents pinning to the old version updated (`PLAN.md`).
- [x] `AMBER-Core-Specification.md` unchanged.
- [x] No Core invariant (§4) or boundary (§5) weakened; Core `§` citations checked.
- [x] Relative links resolve (lychee offline, run locally).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a329f82-6863-492c-b173-04177dd93726?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a329f82-6863-492c-b173-04177dd93726&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

